### PR TITLE
Add basic test for ticker alerts

### DIFF
--- a/.github/workflows/stock_alert.yml
+++ b/.github/workflows/stock_alert.yml
@@ -1,0 +1,34 @@
+name: Stock Alert
+
+on:
+  schedule:
+    - cron: '30 14 * * 1-5'
+    - cron: '0,30 15-20 * * 1-5'
+    - cron: '0 21 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      tickers:
+        description: 'Comma separated tickers, e.g. AAPL:NASDAQ,GOOG:NASDAQ'
+        required: true
+      threshold:
+        description: 'Drop percentage threshold'
+        required: true
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: supplypike/setup-uv@v1
+      - run: uv pip install -r requirements.txt
+      - run: python check_google_finance.py --tickers "$TICKERS" --threshold "$THRESHOLD"
+        env:
+          TICKERS: ${{ github.event.inputs.tickers || env.TICKERS }}
+          THRESHOLD: ${{ github.event.inputs.threshold || env.THRESHOLD }}
+          SMTP_SERVER: ${{ secrets.SMTP_SERVER }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          EMAIL_TO: ${{ secrets.EMAIL_TO }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # stock_alert
+
+This repository contains a simple script and GitHub Actions workflow to check
+stock prices from Google Finance and send an email alert when a price drops more
+than a given percentage.
+
+## Configuration
+
+1. Define the following secrets in your repository settings:
+   - `SMTP_SERVER`
+   - `SMTP_PORT`
+   - `SMTP_USERNAME`
+   - `SMTP_PASSWORD`
+   - `EMAIL_TO`
+   - `EMAIL_FROM`
+
+2. Optionally set default tickers and threshold as repository environment
+   variables `TICKERS` and `THRESHOLD`.
+
+## Running locally
+
+```
+uv pip install -r requirements.txt
+python check_google_finance.py --tickers AAPL:NASDAQ,GOOG:NASDAQ --threshold 5
+```
+
+## GitHub Actions
+
+The workflow in `.github/workflows/stock_alert.yml` runs every 30 minutes during
+US market hours (14:30–21:00 UTC) and can also be triggered manually with
+`workflow_dispatch`.

--- a/check_google_finance.py
+++ b/check_google_finance.py
@@ -1,0 +1,88 @@
+import argparse
+import os
+import re
+import smtplib
+from email.mime.text import MIMEText
+
+import requests
+from bs4 import BeautifulSoup
+
+GOOGLE_FINANCE_QUOTE_URL = "https://www.google.com/finance/quote/{}"
+
+
+def fetch_prices(ticker: str):
+    """Return current and open price for ticker from Google Finance."""
+    url = GOOGLE_FINANCE_QUOTE_URL.format(ticker)
+    resp = requests.get(url, timeout=30)
+    resp.raise_for_status()
+    html = resp.text
+    soup = BeautifulSoup(html, "html.parser")
+    price_el = soup.find("div", {"class": "YMlKec fxKbKc"})
+    if not price_el:
+        raise ValueError(f"Current price not found for {ticker}")
+    current_price = float(price_el.text.replace(",", ""))
+
+    # try to find the day's open value from the html
+    open_val = None
+    open_label = soup.find(string="Open")
+    if open_label:
+        open_el = open_label.find_parent("div")
+        if open_el:
+            val_el = open_el.find_next("div")
+            if val_el and val_el.text:
+                try:
+                    open_val = float(val_el.text.replace(",", ""))
+                except ValueError:
+                    pass
+    if open_val is None:
+        # fallback regex search
+        m = re.search(r'"open":\{"raw":([\d.]+)', html)
+        if m:
+            open_val = float(m.group(1))
+
+    return current_price, open_val
+
+
+def send_email(subject: str, body: str):
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = os.environ['EMAIL_FROM']
+    msg['To'] = os.environ['EMAIL_TO']
+
+    with smtplib.SMTP_SSL(
+        os.environ['SMTP_SERVER'], int(os.environ['SMTP_PORT'])
+    ) as server:
+        server.login(os.environ['SMTP_USERNAME'], os.environ['SMTP_PASSWORD'])
+        server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+
+def check_ticker(ticker: str, threshold: float):
+    current_price, open_price = fetch_prices(ticker)
+    if open_price is None:
+        return
+    drop = (open_price - current_price) / open_price * 100
+    if drop >= threshold:
+        subject = f"{ticker} dropped {drop:.2f}%"
+        body = (
+            f"Ticker {ticker} price is {current_price}, opened at {open_price}.\n"
+            f"Drop: {drop:.2f}% (threshold {threshold}%)"
+        )
+        send_email(subject, body)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check Google Finance for price drops")
+    parser.add_argument("--tickers", required=True, help="Comma separated tickers, e.g. AAPL:NASDAQ,GOOG:NASDAQ")
+    parser.add_argument("--threshold", required=True, type=float, help="Drop percentage threshold")
+    args = parser.parse_args()
+
+    tickers = [t.strip() for t in args.tickers.split(',') if t.strip()]
+    for ticker in tickers:
+        try:
+            check_ticker(ticker, args.threshold)
+        except Exception as exc:
+            print(f"Error processing {ticker}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4

--- a/tests/test_check_google_finance.py
+++ b/tests/test_check_google_finance.py
@@ -1,0 +1,28 @@
+import sys
+import os
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# provide minimal stubs for external dependencies when they are missing
+if 'requests' not in sys.modules:
+    sys.modules['requests'] = types.ModuleType('requests')
+if 'bs4' not in sys.modules:
+    bs4_stub = types.ModuleType('bs4')
+    bs4_stub.BeautifulSoup = object
+    sys.modules['bs4'] = bs4_stub
+
+import check_google_finance as cg
+
+
+def test_check_ticker_sends_email(monkeypatch):
+    monkeypatch.setattr(cg, 'fetch_prices', lambda ticker: (100.0, 110.0))
+    called = {}
+
+    def fake_send_email(subject, body):
+        called['subject'] = subject
+        called['body'] = body
+
+    monkeypatch.setattr(cg, 'send_email', fake_send_email)
+    cg.check_ticker('TEST:NASDAQ', threshold=5.0)
+    assert 'subject' in called and 'body' in called


### PR DESCRIPTION
## Summary
- add pytest for checking email alert trigger

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6882566cc780832e8b702df4af6e1aa8